### PR TITLE
Remove manual steps in favor of PCU duplicate.

### DIFF
--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -1836,10 +1836,6 @@ END
 
 COPY ~%patch_dir%/spl~ ~override~
 
-//update op318s in SoD dragon breath after rename
-COPY_EXISTING ~BGDGBRHT.SPL~ ~override~
-	LPF ALTER_EFFECT STR_VAR match_resource = ~DRGRBRHT~ resource = ~BGDGBRHT~ END
-
 /////                                                  \\\\\
 ///// STO                                              \\\\\
 /////                                                  \\\\\

--- a/EET/lib/bg1_BCS.tph
+++ b/EET/lib/bg1_BCS.tph
@@ -2065,26 +2065,6 @@ COPY_EXISTING ~FTOWBEZ.BCS~ ~override~
 	END
 BUT_ONLY
 
-/////                                                            \\\\\
-///// SoD green dragons share filename with ToB attack           \\\\\
-///// sectypes differ, so DRGRBRHT -> BGDGBRHT rename            \\\\\
-/////                                                            \\\\\
-
-ACTION_FOR_EACH file IN BDDRGGRY BDHALFGR BDMORENT BEGIN
-	COPY_EXISTING ~%file%.BCS~ ~override~
-		DECOMPILE_AND_PATCH BEGIN
-			SPRINT textToReplace ~DrGrBrHt~
-			COUNT_REGEXP_INSTANCES ~%textToReplace%~ num_matches
-			PATCH_IF (num_matches > 0) BEGIN
-				REPLACE_TEXTUALLY ~%textToReplace%~ ~BGDGBRHT~
-				PATCH_PRINT ~Patching: %num_matches% matches found in %SOURCE_FILESPEC% for REPLACE_TEXTUALLY: %textToReplace%~
-			END ELSE BEGIN
-				PATCH_WARN ~WARNING: could not find %textToReplace% in %SOURCE_FILESPEC%~
-			END
-		END
-	BUT_ONLY
-END
-
 //AJANTIS.BCS
 //ALBERT.BCS
 //ALORA.BCS

--- a/EET/lib/bg1_CRE.tph
+++ b/EET/lib/bg1_CRE.tph
@@ -650,14 +650,3 @@ COPY_EXISTING ~YESLIC.CRE~ ~override~
 		WRITE_LONG (0xa4 + nm * 0x4) ~-1~
 	END
 BUT_ONLY
-
-/////                                                            \\\\\
-///// SoD green dragons share filename with ToB attack           \\\\\
-///// sectypes differ, so DRGRBRHT -> BGDGBRHT rename            \\\\\
-/////                                                            \\\\\
-
-ACTION_FOR_EACH file IN BDDRGGRY BDMORENT BDURE4A BDZIATAR BEGIN
-	COPY_EXISTING ~%file%.CRE~ ~override~
-		LPF ALTER_EFFECT STR_VAR match_resource = ~DRGRBRHT~ resource = ~BGDGBRHT~ END
-	BUT_ONLY
-END

--- a/EET/lib/pcu_dict.tph
+++ b/EET/lib/pcu_dict.tph
@@ -1596,7 +1596,8 @@ ACTION_DEFINE_ASSOCIATIVE_ARRAY remapped_spl BEGIN
 	"SPWI935"	=>	"BGWI935"	//SUMMON_SKELETON_WARRIOR3
 	"SPWI936"	=>	"BGWI936"	//SUMMON_SKELETON_WARRIOR2
 	"SPWI937"	=>	"BGWI937"	//SUMMON_SKELETON_WARRIOR
-	"DRGRBRHT"	=>	"BGDGBRHT"
+	"DRGRBRHT"	=>	"BGDGBRHT"	// SoD Green Dragon Breath
+	"DrGrBrHt"	=>	"BGDGBRHT"	// SoD Green Dragon Breath - listed in scripts with mixed case
 //during installation this table is expanded
 END
 

--- a/EET/lib/prep_SPL.tph
+++ b/EET/lib/prep_SPL.tph
@@ -40,6 +40,7 @@ DELETE + ~%patch_dir%/spl/SPIN115.SPL~
 	~%patch_dir%/spl/BDVOID.SPL~
 	~%patch_dir%/spl/BPDISPEL.SPL~
 	~%patch_dir%/spl/DESTSELF.SPL~
+	~%patch_dir%/spl/DRGRBRHT.SPL~
 	~%patch_dir%/spl/FJBARD.SPL~
 	~%patch_dir%/spl/FJBARDA.SPL~
 	~%patch_dir%/spl/FJBARDB.SPL~


### PR DESCRIPTION
DRGRBRHT.SPL is referred in the SoD assets both as fullcaps and mixed-caps DrGrBrHt in the BCS scripts. In the previous PR, I attempted to resolve this via a single PCU entry and then doing the other steps manually, but that led to some changes being attempted to be installed twice.

This PR drops all the manual steps introduced in the prior PR in favor of duplicating the PCU entry to catch both spelling variations.