### PR TITLE
Improve Ambush scripting at SoD ending

### DIFF
--- a/EET/lib/bg1_BCS.tph
+++ b/EET/lib/bg1_BCS.tph
@@ -1289,6 +1289,14 @@ COPY_EXISTING ~BD6100.BCS~ ~override~
 		END ELSE BEGIN
 			PATCH_WARN ~WARNING: could not find %textToReplace% in %SOURCE_FILESPEC%~
 		END
+		SPRINT textToReplace ~StartMovie("sodcin05")~
+		COUNT_REGEXP_INSTANCES ~%textToReplace%~ num_matches
+		PATCH_IF (num_matches > 0) BEGIN
+			REPLACE_TEXTUALLY ~%textToReplace%~ ~StartMovie("sodcin05") FadeFromColor([30.0],0)~
+			PATCH_PRINT ~Patching: %num_matches% matches found in %SOURCE_FILESPEC% for REPLACE_TEXTUALLY: %textToReplace%~
+		END ELSE BEGIN
+			PATCH_WARN ~WARNING: could not find %textToReplace% in %SOURCE_FILESPEC%~
+		END
 		SPRINT textToReplace ~ContinueGame(FALSE)[%newline%]*EndCredits()~
 		COUNT_REGEXP_INSTANCES ~%textToReplace%~ num_matches
 		PATCH_IF (num_matches > 0) BEGIN

--- a/EET/lib/bg1_CRE.tph
+++ b/EET/lib/bg1_CRE.tph
@@ -30,6 +30,13 @@ COPY_EXISTING ~addy.cre~ ~override~
 BUT_ONLY
 
 /////                                                 \\\\\
+/////EA                                               \\\\\
+/////                                                 \\\\\
+COPY_EXISTING ~bdfinal3.cre~ ~override~
+	WRITE_BYTE 0x270 128 // Neutral
+BUT_ONLY
+
+/////                                                 \\\\\
 /////NPC soundsets                                    \\\\\
 /////                                                 \\\\\
 


### PR DESCRIPTION
- Fixes fade-from-black after the Ambush cinematic
- Fixes a creature allegiance to prevent _Auto-Pause: Enemy Sighted_ from triggering during the transition cutscene