### PR TITLE
Don't delete BG1:EE version of AX1H06.ITM (Rhyte's Last Arrow +2)

### DIFF
--- a/EET/lib/prep_ITM.tph
+++ b/EET/lib/prep_ITM.tph
@@ -136,7 +136,7 @@ DELETE + ~%patch_dir%/itm/BAG02.ITM~
 	~%patch_dir%/itm/AX1H03.ITM~
 	~%patch_dir%/itm/AX1H04.ITM~
 	~%patch_dir%/itm/AX1H05.ITM~
-	~%patch_dir%/itm/AX1H06.ITM~
+	//~%patch_dir%/itm/AX1H06.ITM~ //BG2:EE item still has vanilla BG1 bug
 	~%patch_dir%/itm/AX1H11.ITM~
 	~%patch_dir%/itm/AX1H16.ITM~
 	~%patch_dir%/itm/AX1H17.ITM~


### PR DESCRIPTION
BG2:EE version of AX1H06.ITM has no unique name and is bugged:
It creates a duplicate on every ranged hit.