### PR TITLE
Don't delete WENCH0*.WAV in German

### DIFF
--- a/EET/lib/prep_WAV.tph
+++ b/EET/lib/prep_WAV.tph
@@ -161,6 +161,10 @@ ACTION_IF NOT ~%LANGUAGE_BG2%~ STR_EQ ~de_DE~ BEGIN
 		~%MOD_FOLDER%/temp/wav/CHANT06.WAV~
 		~%MOD_FOLDER%/temp/wav/CHANT07.WAV~
 		~%MOD_FOLDER%/temp/wav/CHANT220.WAV~
+		~%MOD_FOLDER%/temp/wav/WENCH01.WAV~
+		~%MOD_FOLDER%/temp/wav/WENCH02.WAV~
+		~%MOD_FOLDER%/temp/wav/WENCH03.WAV~
+		~%MOD_FOLDER%/temp/wav/WENCH04.WAV~
 END
 
 // Some sets were rerecorded between BG1 and BG2, restore BG1
@@ -3241,10 +3245,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/WAL_MTA.WAV~
 	~%MOD_FOLDER%/temp/wav/WAL_MTB.WAV~
 	~%MOD_FOLDER%/temp/wav/WAL_MTC.WAV~
-	~%MOD_FOLDER%/temp/wav/WENCH01.WAV~
-	~%MOD_FOLDER%/temp/wav/WENCH02.WAV~
-	~%MOD_FOLDER%/temp/wav/WENCH03.WAV~
-	~%MOD_FOLDER%/temp/wav/WENCH04.WAV~
 	~%MOD_FOLDER%/temp/wav/WEREG_01.WAV~
 	~%MOD_FOLDER%/temp/wav/WEREG_02.WAV~
 	~%MOD_FOLDER%/temp/wav/WEREG_03.WAV~


### PR DESCRIPTION
In German version of BG2:EE these files are corrupt.