### PR TITLE
Add Russian translation with compatible EET names

### DIFF
--- a/EET/tbl/compatibility.tbl
+++ b/EET/tbl/compatibility.tbl
@@ -3,6 +3,7 @@ BWS 0                //dummy entry from Big World Setup
 BWS-URL 0            //dummy entry from Big World Setup
 DLCMERGER 0          //DLC Merger
 BGEETEXTPACK 0       //RUS BG1
+BGEETEXTPACKEETNAMES 0 //RUS BG1 with BG2 Russian translation compatible names
 SODRUS 0             //RUS SOD
 EEFIXPACK 0          //EE Fixpack
 CORRECTFRBG1EE 0     //FR BG1 / SoD


### PR DESCRIPTION
Hi, can you add BGEETEXTPACKEETNAMES mod to the compatibility list as it was discussed in #84, please?

This mod is a BG1EE Russian translation (based on original BGEETEXTPACK)  with mainly compatible names for BG2EE Russian translation. 

The long story is: It happened to be that BG1EE and BG2EE official Russian translations were made by two different people and they didn't have the common list how to translate names. So, it is a difference in eg Gorion Russian translation for BG1EE and BG2EE and many other names. Later, the Russian community tried to fix this issue using different means, and this mod is one of them. Russian community already used this mod for the last couple of years for EET installations, however I had to have a branch of EET with this mod in the list (and other ones before, but now it is the only one left). It would be great if you can include this mod into the compatibility list.

Thank you.
