### PR TITLE
Don't delete CMISC52.BAM and CMISC54.BAM

### DIFF
--- a/EET/lib/prep_BAM.tph
+++ b/EET/lib/prep_BAM.tph
@@ -3195,9 +3195,9 @@ DELETE + ~%biff_dir%/IAX1H04.BAM~
 	~%biff_dir%/CMISC4Z.BAM~
 	~%biff_dir%/CMISC50.BAM~
 	~%biff_dir%/CMISC51.BAM~
-	~%biff_dir%/CMISC52.BAM~
+	//~%biff_dir%/CMISC52.BAM~
 	~%biff_dir%/CMISC53.BAM~
-	~%biff_dir%/CMISC54.BAM~
+	//~%biff_dir%/CMISC54.BAM~
 	~%biff_dir%/CMISC56.BAM~
 	~%biff_dir%/CMISC57.BAM~
 	~%biff_dir%/CMISC58.BAM~


### PR DESCRIPTION
In BG2:EE these files have ugly black backgrounds.

Files are used in MISC52.ITM and MISC54.ITM.