### PR TITLE
Make Windows desktop shortcut creation more robust

### DIFF
--- a/EET/lib/shortcut_windows.tph
+++ b/EET/lib/shortcut_windows.tph
@@ -2,8 +2,8 @@
 
 <<<<<<<< .../userprofile.bat
 @echo off
-for /f "usebackq tokens=3*" %%D IN (`reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Desktop`) do set DESKTOP=%%D
-for /F  %%a in ('echo %DESKTOP%') do echo %%a>EET/temp/path.txt
+for /f "tokens=3,*" %%a in ('reg query "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders" /v Desktop') do set DESKTOP=%%a
+for /f "delims=" %%a in ('echo %DESKTOP%') do echo %%a>EET/temp/path.txt
 >>>>>>>>
 
 //we're not setting %DESKTOP% in sLinkFile but echo and read it from external file (otherwise shortcut would not be registered for uninstallation)


### PR DESCRIPTION
This fix correctly handles user names that consist of multiple words. (Fixes #114)

Note:
User names with non-ASCII characters may still cause issues (like #76) as that would require individually tailored codepage changes based on the present character set.