### PR TITLE
Restore fire spark UI effects on start screen when SoD campaign is selected

### DIFF
--- a/EET/lib/bg1_GUI.tph
+++ b/EET/lib/bg1_GUI.tph
@@ -757,7 +757,7 @@ menu
 
 	movie
 	{
-		--enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
+		enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
 		name "flames"
 		area 86 222 512 512
 		loop
@@ -1078,7 +1078,7 @@ menu
 	}
 	movie
 	{
-		--enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
+		enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
 		name "flames2"
 		area 86 222 512 512
 		loop
@@ -1158,7 +1158,7 @@ menu
 		STR_VAR
 		pattern = ~~~~~enabled "startEngine:GetCampaign() == const.START_CAMPAIGN_SOD"
 		name "flames~~~~~
-		string = ~~~~~--enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
+		string = ~~~~~enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
 		name "flames~~~~~
 	END
 	//==========================================================================

--- a/EET/lib/bg2_GUI.tph
+++ b/EET/lib/bg2_GUI.tph
@@ -661,6 +661,13 @@ menu
 		"
 	}
 	
+	movie
+	{
+		enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
+		name "flames"
+		area 373 272 276 296
+		loop
+	}
 	label
 	{
 		area 463 0 94 47
@@ -784,6 +791,7 @@ menu
 	name 'START_SP'
 	align center center
 	ignoreEsc
+	onopen "Infinity_PlayMovie('flames','flames2')"
 
 	label
 	{
@@ -905,6 +913,13 @@ menu
 		text "BACK_BUTTON"
 		action "startEngine:SetEngineState(0); Infinity_TransitionMenu('START')"
 	}
+	movie
+	{
+		enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
+		name "flames2"
+		area 373 272 276 296
+		loop
+	}
 	label
 	{
 		area 463 0 94 47
@@ -996,6 +1011,210 @@ menu
 		string = ~~~~~optionsScreen:SaveGame(0)
 		"
 	}~~~~~
+	END
+	//==========================================================================
+	LPF REPLACE_MULTILINE
+		INT_VAR
+		num = 1
+		strict = 1
+		STR_VAR
+		pattern = ~~~~~menu
+{
+	name 'START_OPTIONS'
+	align center center
+	ignoreEsc
+
+	label
+	{
+		area 0 0 1024 768
+		mosaic 'START'
+	}
+	label
+	{
+		area 112 26 786 202	
+		bam 'TITLE'
+		sequence 0 -- sequence lua 'initCampaign == 0'
+		align center center
+		frame lua 'logoFrame'
+	}
+	label
+	{
+		area 338 192 352 456	
+		bam 'BIGLOGO'
+		align center center
+		frame lua 'logoFrame'
+	}
+
+	button
+	{
+		bam 'STARTMBT'
+		sequence 0
+		area 112 294 262 74
+		pad 10 8 10 8
+		text style "button"
+		text "SOUND_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_SOUND' )"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 3
+		area 649 300 266 74
+		pad 10 8 10 8
+		text style "button"
+		text "GRAPHICS_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_GRAPHICS' )"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 1
+		area 112 374 236 84
+		pad 10 8 10 8
+		text style "button"
+		text "LANGUAGE_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_LANGUAGE' )"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 4
+		area 682 378 233 84
+		pad 10 8 10 8
+		text style "button"
+		text "MOVIES_BUTTON"
+		action "e:SelectEngine(moviesScreen)"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 2
+		area 116 462 262 76
+		pad 10 8 10 8
+		text style "button"
+		text "GAMEPLAY_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_GAMEPLAY' )"
+	}
+	button
+	{
+		on escape
+		area 649 462 260 76
+		bam 'STARTMBT'
+		sequence 5
+		pad 10 8 10 8
+		text style "button"
+		text "BACK_BUTTON"
+		action
+		"
+			Infinity_PopMenu()
+			e:SelectEngine(startEngine)
+		"
+	}
+}~~~~~
+		string = ~~~~~menu
+{
+	name 'START_OPTIONS'
+	align center center
+	ignoreEsc
+	onopen
+	"
+		Infinity_PlayMovie('flames','flames3')
+	"
+
+	label
+	{
+		area 0 0 1024 768
+		mosaic 'START'
+	}
+	label
+	{
+		area 112 26 786 202	
+		bam 'TITLE'
+		sequence 0 -- sequence lua 'initCampaign == 0'
+		align center center
+		frame lua 'logoFrame'
+	}
+	label
+	{
+		area 338 192 352 456	
+		bam 'BIGLOGO'
+		align center center
+		frame lua 'logoFrame'
+	}
+
+	button
+	{
+		bam 'STARTMBT'
+		sequence 0
+		area 112 294 262 74
+		pad 10 8 10 8
+		text style "button"
+		text "SOUND_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_SOUND' )"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 3
+		area 649 300 266 74
+		pad 10 8 10 8
+		text style "button"
+		text "GRAPHICS_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_GRAPHICS' )"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 1
+		area 112 374 236 84
+		pad 10 8 10 8
+		text style "button"
+		text "LANGUAGE_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_LANGUAGE' )"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 4
+		area 682 378 233 84
+		pad 10 8 10 8
+		text style "button"
+		text "MOVIES_BUTTON"
+		action "e:SelectEngine(moviesScreen)"
+	}
+	button
+	{
+		bam 'STARTMBT'
+		sequence 2
+		area 116 462 262 76
+		pad 10 8 10 8
+		text style "button"
+		text "GAMEPLAY_BUTTON"
+		action "Infinity_PushMenu( 'OPTIONS_GAMEPLAY' )"
+	}
+	button
+	{
+		on escape
+		area 649 462 260 76
+		bam 'STARTMBT'
+		sequence 5
+		pad 10 8 10 8
+		text style "button"
+		text "BACK_BUTTON"
+		action
+		"
+			Infinity_PopMenu()
+			e:SelectEngine(startEngine)
+		"
+	}
+	movie
+	{
+		enabled "Infinity_GetINIValue('Program Options','Active Campaign') == const.START_CAMPAIGN_SOD"
+		name "flames3"
+		area 373 272 276 296
+		loop
+	}
+}~~~~~
 	END
 	//==========================================================================
 	REPLACE_TEXTUALLY ~frame lua 'logoFrame'~ ~frame lua "getTitle()"~


### PR DESCRIPTION
- Introduces a modified fire spark vfx to the default EET GUI.
- Restores the original fire spark vfx in "EET_gui"*.

<em>*) The vfx was originally disabled in "EET_gui". @K4thos Let me know if there was a good reason for this, and I will undo the changes for "EET_gui".</em>