### PR TITLE
Don't delete specific German *.WAV files

### DIFF
--- a/EET/lib/prep_WAV.tph
+++ b/EET/lib/prep_WAV.tph
@@ -161,6 +161,36 @@ ACTION_IF NOT ~%LANGUAGE_BG2%~ STR_EQ ~de_DE~ BEGIN
 		~%MOD_FOLDER%/temp/wav/CHANT06.WAV~
 		~%MOD_FOLDER%/temp/wav/CHANT07.WAV~
 		~%MOD_FOLDER%/temp/wav/CHANT220.WAV~
+		~%MOD_FOLDER%/temp/wav/GENFG01.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOME01.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOME02.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOME03.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOME04.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOME05.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOME06.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOMF01.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOMF02.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOMF03.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOMF05.WAV~
+		~%MOD_FOLDER%/temp/wav/GNOMF06.WAV~
+		~%MOD_FOLDER%/temp/wav/GUARR01.WAV~
+		~%MOD_FOLDER%/temp/wav/GUARR02.WAV~
+		~%MOD_FOLDER%/temp/wav/GUARR03.WAV~
+		~%MOD_FOLDER%/temp/wav/GUARR04.WAV~
+		~%MOD_FOLDER%/temp/wav/GUARR05.WAV~
+		~%MOD_FOLDER%/temp/wav/GUARR06.WAV~
+		~%MOD_FOLDER%/temp/wav/IKEEE_01.WAV~
+		~%MOD_FOLDER%/temp/wav/IKEEE_02.WAV~
+		~%MOD_FOLDER%/temp/wav/IKEEE_03.WAV~
+		~%MOD_FOLDER%/temp/wav/IKEEE_05.WAV~
+		~%MOD_FOLDER%/temp/wav/IKEEE_06.WAV~
+		~%MOD_FOLDER%/temp/wav/OGHMA03.WAV~
+		~%MOD_FOLDER%/temp/wav/OGHMA04.WAV~
+		~%MOD_FOLDER%/temp/wav/TWOMN01.WAV~
+		~%MOD_FOLDER%/temp/wav/TWOMN02.WAV~
+		~%MOD_FOLDER%/temp/wav/TWOMN03.WAV~
+		~%MOD_FOLDER%/temp/wav/TWOMN04.WAV~
+		~%MOD_FOLDER%/temp/wav/VAMPM07.WAV~
 		~%MOD_FOLDER%/temp/wav/WENCH01.WAV~
 		~%MOD_FOLDER%/temp/wav/WENCH02.WAV~
 		~%MOD_FOLDER%/temp/wav/WENCH03.WAV~
@@ -1545,7 +1575,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/GDWARF02.WAV~
 	~%MOD_FOLDER%/temp/wav/GDWARF03.WAV~
 	~%MOD_FOLDER%/temp/wav/GDWARF04.WAV~
-	~%MOD_FOLDER%/temp/wav/GENFG01.WAV~
 	~%MOD_FOLDER%/temp/wav/GENFG02.WAV~
 	~%MOD_FOLDER%/temp/wav/GENFG03.WAV~
 	~%MOD_FOLDER%/temp/wav/GENFG04.WAV~
@@ -1676,12 +1705,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOLL08.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOLL09.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOLL10.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOME01.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOME02.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOME03.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOME04.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOME05.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOME06.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOMEF01.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOMEF02.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOMEF03.WAV~
@@ -1698,11 +1721,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOMEM06.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOMEM07.WAV~
 	~%MOD_FOLDER%/temp/wav/GNOMEM08.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOMF01.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOMF02.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOMF03.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOMF05.WAV~
-	~%MOD_FOLDER%/temp/wav/GNOMF06.WAV~
 	~%MOD_FOLDER%/temp/wav/GOBAXE1.WAV~
 	~%MOD_FOLDER%/temp/wav/GOBAXE10.WAV~
 	~%MOD_FOLDER%/temp/wav/GOBAXE11.WAV~
@@ -1798,12 +1816,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/GSPID08.WAV~
 	~%MOD_FOLDER%/temp/wav/GSPID09.WAV~
 	~%MOD_FOLDER%/temp/wav/GSPID10.WAV~
-	~%MOD_FOLDER%/temp/wav/GUARR01.WAV~
-	~%MOD_FOLDER%/temp/wav/GUARR02.WAV~
-	~%MOD_FOLDER%/temp/wav/GUARR03.WAV~
-	~%MOD_FOLDER%/temp/wav/GUARR04.WAV~
-	~%MOD_FOLDER%/temp/wav/GUARR05.WAV~
-	~%MOD_FOLDER%/temp/wav/GUARR06.WAV~
 	~%MOD_FOLDER%/temp/wav/GULP.WAV~
 	~%MOD_FOLDER%/temp/wav/HALFF01.WAV~
 	~%MOD_FOLDER%/temp/wav/HALFF02.WAV~
@@ -1908,11 +1920,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/HVILLM06.WAV~
 	~%MOD_FOLDER%/temp/wav/HVILLM07.WAV~
 	~%MOD_FOLDER%/temp/wav/HVILLM08.WAV~
-	~%MOD_FOLDER%/temp/wav/IKEEE_01.WAV~
-	~%MOD_FOLDER%/temp/wav/IKEEE_02.WAV~
-	~%MOD_FOLDER%/temp/wav/IKEEE_03.WAV~
-	~%MOD_FOLDER%/temp/wav/IKEEE_05.WAV~
-	~%MOD_FOLDER%/temp/wav/IKEEE_06.WAV~
 	~%MOD_FOLDER%/temp/wav/IMPPP01.WAV~
 	~%MOD_FOLDER%/temp/wav/IMPPP02.WAV~
 	~%MOD_FOLDER%/temp/wav/IMPPP03.WAV~
@@ -2255,8 +2262,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/ODREN08.WAV~
 	~%MOD_FOLDER%/temp/wav/OGHMA01.WAV~
 	~%MOD_FOLDER%/temp/wav/OGHMA02.WAV~
-	~%MOD_FOLDER%/temp/wav/OGHMA03.WAV~
-	~%MOD_FOLDER%/temp/wav/OGHMA04.WAV~
 	~%MOD_FOLDER%/temp/wav/OGHMA05.WAV~
 	~%MOD_FOLDER%/temp/wav/OGHMA06.WAV~
 	~%MOD_FOLDER%/temp/wav/OGREE01.WAV~
@@ -3009,10 +3014,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/TTXAN10.WAV~
 	~%MOD_FOLDER%/temp/wav/TTXAN11.WAV~
 	~%MOD_FOLDER%/temp/wav/TUTHH04.WAV~
-	~%MOD_FOLDER%/temp/wav/TWOMN01.WAV~
-	~%MOD_FOLDER%/temp/wav/TWOMN02.WAV~
-	~%MOD_FOLDER%/temp/wav/TWOMN03.WAV~
-	~%MOD_FOLDER%/temp/wav/TWOMN04.WAV~
 	~%MOD_FOLDER%/temp/wav/UDSOLA01.WAV~
 	~%MOD_FOLDER%/temp/wav/UDSOLA03.WAV~
 	~%MOD_FOLDER%/temp/wav/UDSOLA04.WAV~
@@ -3061,7 +3062,6 @@ DELETE + ~%MOD_FOLDER%/temp/wav/EFF_M46.WAV~
 	~%MOD_FOLDER%/temp/wav/VAMPM04.WAV~
 	~%MOD_FOLDER%/temp/wav/VAMPM05.WAV~
 	~%MOD_FOLDER%/temp/wav/VAMPM06.WAV~
-	~%MOD_FOLDER%/temp/wav/VAMPM07.WAV~
 	~%MOD_FOLDER%/temp/wav/VAMPM08.WAV~
 	~%MOD_FOLDER%/temp/wav/VAMPM09.WAV~
 	~%MOD_FOLDER%/temp/wav/VAMPP01.WAV~


### PR DESCRIPTION
In German version of BG2:EE some files are corrupt.
Some are already handled in PR #100 but not all.
<br>
<details>
<summary>This is a list of all corrupt German *.WAV files in BG2:EE</summary>

- 2YAGA23.WAV
- BODHIX15.WAV
- BODHIX17.WAV
- CELOGA04.WAV
- CHANT01.WAV
- CHANT01B.WAV
- CHANT02.WAV
- CHANT03.WAV
- CHANT04.WAV
- CHANT05.WAV
- CHANT06.WAV
- CHANT07.WAV
- CHANT220.WAV
- DEMSON20.WAV
- GDWARF01.WAV
- GDWARF02.WAV
- GDWARF03.WAV
- GDWARF04.WAV
- GENFG01.WAV
- GGFEM01.WAV
- GGFEM02.WAV
- GGFEM03.WAV
- GGFEM04.WAV
- GGFEM05.WAV
- GGMAL01.WAV
- GGMAL02.WAV
- GGMAL03.WAV
- GGMAL04.WAV
- GNFEM01.WAV
- GNFEM02.WAV
- GNFEM03.WAV
- GNFEM04.WAV
- GNMAL01.WAV
- GNMAL02.WAV
- GNMAL03.WAV
- GNMAL201.WAV
- GNMAL202.WAV
- GNMAL203.WAV
- GNOME01.WAV
- GNOME02.WAV
- GNOME03.WAV
- GNOME04.WAV
- GNOME05.WAV
- GNOME06.WAV
- GNOMF01.WAV
- GNOMF02.WAV
- GNOMF03.WAV
- GNOMF05.WAV
- GNOMF06.WAV
- GUARR01.WAV
- GUARR02.WAV
- GUARR03.WAV
- GUARR04.WAV
- GUARR05.WAV
- GUARR06.WAV
- HELMP03.WAV
- IKEEE_01.WAV
- IKEEE_02.WAV
- IKEEE_03.WAV
- IKEEE_05.WAV
- IKEEE_06.WAV
- IMOEN07.WAV
- IMOEN17.WAV
- IMOEN71A.WAV
- IMOEN71B.WAV
- IMOEN77A.WAV
- IMOEN77B.WAV
- IMOEN79A.WAV
- IMOEN79B.WAV
- LATHAN18.WAV
- LATHAN19.WAV
- LEHTIN04.WAV
- LEHTIN21.WAV
- LOUT03.WAV
- NARR05.WAV
- OGHMA03.WAV
- OGHMA04.WAV
- SAFAN42.WAV
- SAFAN43.WAV
- SAFAN44.WAV
- SAFAN45.WAV
- SAFAN46.WAV
- SAFAN47.WAV
- SOLAR35.WAV
- SOLAR66.WAV
- TEOSXX04.WAV
- TEOSXX05.WAV
- TWOMN01.WAV
- TWOMN02.WAV
- TWOMN03.WAV
- TWOMN04.WAV
- UNEARM08.WAV
- VALYGA99.WAV
- VAMPM07.WAV
- WENCH01.WAV
- WENCH02.WAV
- WENCH03.WAV
- WENCH04.WAV
</details>

<details>
<summary>And these files can also be found in BGEE and will replace corrupt BG2:EE files</summary>

- CHANT01.WAV
- CHANT01B.WAV
- CHANT02.WAV
- CHANT03.WAV
- CHANT04.WAV
- CHANT05.WAV
- CHANT06.WAV
- CHANT07.WAV
- CHANT220.WAV
- GENFG01.WAV
- GNOME01.WAV
- GNOME02.WAV
- GNOME03.WAV
- GNOME04.WAV
- GNOME05.WAV
- GNOME06.WAV
- GNOMF01.WAV
- GNOMF02.WAV
- GNOMF03.WAV
- GNOMF05.WAV
- GNOMF06.WAV
- GUARR01.WAV
- GUARR02.WAV
- GUARR03.WAV
- GUARR04.WAV
- GUARR05.WAV
- GUARR06.WAV
- IKEEE_01.WAV
- IKEEE_02.WAV
- IKEEE_03.WAV
- IKEEE_05.WAV
- IKEEE_06.WAV
- OGHMA03.WAV
- OGHMA04.WAV
- TWOMN01.WAV
- TWOMN02.WAV
- TWOMN03.WAV
- TWOMN04.WAV
- VAMPM07.WAV
- WENCH01.WAV
- WENCH02.WAV
- WENCH03.WAV
- WENCH04.WAV
</details>